### PR TITLE
Add PCA/Outlier Detection, Subsampling, Visualization & Topogene Scoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# Editable install metadata
+*.egg-info/

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ import totopos.cells as tpc
 adata = ad.read_h5ad("path/to/sc.h5ad")
 
 # Compute persistent homology and determine if there are topological loops
-ph = ripser(adata.obsm["pcs"])
+ph = ripser(adata.obsm["pcs"], do_cocycles=True)
 
 # Compute topoCells
 topological_loops = tpc.critical_edge_method(adata.obsm["pcs"], ph, n_loops=1)

--- a/examples/tutorial_2.ipynb
+++ b/examples/tutorial_2.ipynb
@@ -1,0 +1,745 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### preprocessing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%cd /home/binglun/totopos_testing/data "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%cd /home/binglun/totopos_testing/data \n",
+    "%load_ext autoreload\n",
+    "%autoreload 2 \n",
+    "import numpy as np\n",
+    "import anndata as ad\n",
+    "import sc\n",
+    "from plotly import express as px\n",
+    "from ripser import ripser\n",
+    "from persim import plot_diagrams"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "adata = ad.read_h5ad('E8.5b.h5ad')\n",
+    "adata"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import mygene\n",
+    "\n",
+    "mg = mygene.MyGeneInfo()\n",
+    "ensembl_ids = adata.var['features'].tolist()\n",
+    "result = mg.querymany(ensembl_ids, scopes='ensembl.gene', fields='symbol', species='mouse')\n",
+    "id_to_symbol = {entry['query']: entry.get('symbol', None) for entry in result}\n",
+    "adata.var['gene_name'] = adata.var['features'].map(id_to_symbol)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "adata.raw.var.rename(columns={'_index': 'index_backup'}, inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "adata.write_h5ad('E8.5b.h5ad', compression='gzip')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mt_ribo_filt = True\n",
+    "if mt_ribo_filt:\n",
+    "    #try human \n",
+    "    if adata.var[\"gene_name\"].str.contains(\"MT-\").any():\n",
+    "        print(\"Detected human gene name format for mitochondrial genes.\")\n",
+    "        a = sc.get_count_stats(adata, mt_prefix=\"MT-\", \n",
+    "                               ribo_prefix = (\"RPS\", \"RPL\"))\n",
+    "    #try mouse \n",
+    "    elif adata.var[\"gene_name\"].str.contains(\"mt-\").any(): \n",
+    "        print(\"Detected mouse gene name format for mitochondrial genes.\")\n",
+    "        a = sc.get_count_stats(adata, mt_prefix=\"mt-\", \n",
+    "                               ribo_prefix = (\"Rps\", \"Rpl\"))\n",
+    "    else: #TO-DO allow for arbitrary prefixes\n",
+    "        print(\"Could not calculate mitochondrial and \\\n",
+    "              ribosomal gene content.\")\n",
+    "        mt_ribo_filt = False\n",
+    "else:\n",
+    "    a = sc.get_count_stats(adata)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "adata.obs['n_counts'] = np.asarray(adata.X.sum(axis = 1))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "adata.obs['log_counts'] = np.log10(adata.obs.n_counts)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "adata.obs['n_genes'] = np.asarray((adata.X > 0).sum(axis = 1))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mito_genes = adata.var['gene_name'].str.startswith('mt-')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mito_inds = np.where(adata.var['gene_name'].str.startswith('mt-'))[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "adata.obs[\"frac_mito\"] = adata[:, mito_inds].X.toarray().sum(axis =1) / adata.obs.n_counts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ribo_prefix = (\"Rps\", \"Rpl\")\n",
+    "ribo_genes = np.zeros(adata.n_vars, dtype = bool)\n",
+    "for prefix in ribo_prefix:\n",
+    "    ribo_genes_tmp = adata.var['gene_name'].str.startswith(prefix)\n",
+    "    ribo_genes +=ribo_genes_tmp"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ribo_inds = np.where(ribo_genes)[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "adata.obs[\"frac_ribo\"] = adata[:, ribo_inds].X.toarray().sum(axis =1) / adata.obs.n_counts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "adata.write_h5ad('E8.5b.h5ad', compression='gzip')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "adata.obs['n_counts'].describe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a = adata"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import scipy.sparse\n",
+    "if scipy.sparse.issparse(a.X):\n",
+    "    # Using getnnz counts the nonzero entries along the axis (axis=0 for genes)\n",
+    "    gene_cell_counts = a.X.getnnz(axis=0)\n",
+    "else:\n",
+    "    gene_cell_counts = np.sum(a.X > 0, axis=0)\n",
+    "\n",
+    "min_cells = 10                         # Gene must be expressed in at least 10 cells\n",
+    "max_cells = 0.9 * a.n_obs            # Gene expressed in >60% of cells is excluded\n",
+    "genes_to_keep = (gene_cell_counts >= min_cells) & (gene_cell_counts <= max_cells)\n",
+    "a = a[:, genes_to_keep]\n",
+    "a"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import scanpy\n",
+    "scanpy.pl.violin(a, ['n_genes', 'n_counts', 'frac_mito', 'frac_ribo'],\n",
+    "    jitter=0.4, multi_panel=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "max_frac_mito = 0.2\n",
+    "max_frac_ribo = 0.2\n",
+    "\n",
+    "filtered_cells = a[(a.obs['frac_mito'] > max_frac_mito) \n",
+    "                   | (a.obs['frac_ribo'] > max_frac_ribo)]\n",
+    "print(f\"Number of cells with max_frac_mito > {max_frac_mito} \\\n",
+    "      or max_frac_ribo > {max_frac_ribo}: {filtered_cells.n_obs} \\n\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a_ = a\n",
+    "mito_ribo_filt = True\n",
+    "if mito_ribo_filt: \n",
+    "    try: \n",
+    "        print(f\"Mean frac mitochondrial counts \\\n",
+    "              {a_.obs.frac_mito.mean():.2f}, \\\n",
+    "                ribosomal gene counts {a_.obs.frac_ribo.mean():.2f}\")        \n",
+    "        a_ = a_[(a_.obs.frac_mito < max_frac_mito) & \\\n",
+    "                (a_.obs.frac_ribo < max_frac_ribo)].copy()\n",
+    "        print(f\"Filtered out cells with max.frac of mitochondrial \\\n",
+    "              {max_frac_mito}  and {max_frac_ribo} of ribosomal counts.\")\n",
+    "    except: \n",
+    "        print(\"Could not perform filtering by ribo/mito content.\")\n",
+    "\n",
+    "print(f\"Number of cells after filtering: {a_.n_obs}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    ada = sc.lognorm_cells(a_)\n",
+    "except: \n",
+    "    a_.X = a_.X.astype(np.float32)\n",
+    "    ada = sc.lognorm_cells(a_)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "adat = sc.cv_filter(ada, return_highly_variable = True)\n",
+    "print(f\"Number of genes after filtering: {adat.n_vars}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 62,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "adat.write_h5ad('E8.5b_hvg.h5ad', compression='gzip')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "adat"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### totopos"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2 \n",
+    "import totopos.cells as tpc\n",
+    "\n",
+    "n_pcs = tpc.find_pca_cutoff(adat, thres=0.01)\n",
+    "print(f'Number of PCs: {n_pcs}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "adat"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "outlier_mask, scores = tpc.detect_outliers(\n",
+    "    adat, n_pcs=n_pcs, contamination=0.01, max_samples=100000, \n",
+    "    n_jobs=8, n_estimators=200)\n",
+    "\n",
+    "adat.obs['if_outlier_mask'] = outlier_mask\n",
+    "adat.obs['if_outlier_score'] = scores"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tpc.plot_outliers(adat, outlier_mask, scores)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig=px.scatter_3d(\n",
+    "    adat.obs,\n",
+    "    # x=\"UMAP_1\", y = \"UMAP_2\", z = \"UMAP_3\", \n",
+    "    x=\"pc1\", y=\"pc2\", z=\"pc3\", \n",
+    "    color = 'if_outlier_mask', \n",
+    "    # hover_data=[\"cell_type\", 'E_day', 'author_cell_type'], \n",
+    "    width=1000, height=800\n",
+    ")\n",
+    "fig.update_traces(marker=dict(size=1))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 68,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "adat.write_h5ad('E8.5b_hvg_outliers.h5ad', compression='gzip')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### tpc"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/home/binglun/totopos_testing/data\n"
+     ]
+    }
+   ],
+   "source": [
+    "%cd /home/binglun/totopos_testing/data \n",
+    "%load_ext autoreload\n",
+    "%autoreload 2 \n",
+    "import numpy as np\n",
+    "import anndata as ad\n",
+    "import pandas as pd\n",
+    "import sc\n",
+    "from plotly import express as px\n",
+    "from ripser import ripser\n",
+    "from persim import plot_diagrams"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "AnnData object with n_obs × n_vars = 153073 × 6588\n",
+       "    obs: 'orig.ident', 'nCount_RNA', 'nFeature_RNA', 'sample', 'day', 'group', 'cell_state', 'cell_type', 'somite_stage', 'n_counts', 'log_counts', 'n_genes', 'frac_mito', 'frac_ribo', 'doublet_score', 'predicted_doublet', 'pc1', 'pc2', 'pc3', 'pc4', 'if_outlier_mask', 'if_outlier_score'\n",
+       "    var: 'features', 'gene_name', 'mean', 'log_mean', 'var', 'cv', 'log_cv', 'highly_variable'\n",
+       "    obsm: 'pcs'"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "adata = ad.read_h5ad('E8.5b_hvg_outliers.h5ad')\n",
+    "adata"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ph = ripser(adata.obsm[\"pcs\"][:, :35], n_perm=1000, do_cocycles=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Starting VR graph construction.\n",
+      "Finished VR graph. Starting loop discovery...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "  0%|          | 0/3 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Starting 1-th loop discovery...\n",
+      "Finished computing loop 1 from VR graph.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 33%|███▎      | 1/3 [00:00<00:01,  1.41it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Starting 2-th loop discovery...\n",
+      "Finished computing loop 2 from VR graph.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 67%|██████▋   | 2/3 [00:01<00:00,  1.47it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Starting 3-th loop discovery...\n",
+      "Finished computing loop 3 from VR graph.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 3/3 [00:02<00:00,  1.42it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Finished critical edge algorithm.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "import totopos.cells as tpc\n",
+    "topological_loops = tpc.critical_edge_method(adata.obsm[\"pcs\"][:, :35], ph, verbose=True, n_loops=3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### plot loops/topocells"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import totopos.viz.cloud as tpv\n",
+    "tpv.quick_loop_summary(topological_loops)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = tpv.plot_loops(\n",
+    "    adata=adata,\n",
+    "    topological_loops=topological_loops,\n",
+    "    title=\"Topological Loops in Single-Cell Data\",\n",
+    "    pcs_viz=(1, 2, 3),  # Use PC1, PC2, PC3\n",
+    "    # color_col='cell_type',  # Color by cell type\n",
+    "    hover_cols=['cell_type', 'sample', 'day'],  # Show in hover\n",
+    "    use_pca=True  # Use PCA coordinates from adata.obsm['pcs']\n",
+    ")\n",
+    "\n",
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tpv.summarize_topocells(adata, topological_loops)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig1 = tpv.plot_topocells_highlighted(\n",
+    "    adata=adata,\n",
+    "    topological_loops=topological_loops,\n",
+    "    title=\"All Topocells Highlighted\",\n",
+    "    # color_col='cell_type',  # Color topocells by cell type\n",
+    "    hover_cols=['cell_type', 'sample', 'day'],\n",
+    "    pcs_viz=(1, 2, 3),\n",
+    "    dot_size_gray=1,  # Small gray dots\n",
+    "    dot_size_topo=3,  # Larger colored dots\n",
+    "    show_loops=True   # Also show connections\n",
+    ")\n",
+    "\n",
+    "fig1.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig2 = tpv.plot_single_loop_topocells(\n",
+    "    adata=adata,\n",
+    "    topological_loops=topological_loops,\n",
+    "    loop_index=1,  # First loop\n",
+    "    # color_col='somite_stage',\n",
+    "    pcs_viz=(1, 2, 3),\n",
+    "    hover_cols=['cell_type', 'somite_stage', 'day'],\n",
+    "    show_loops=True\n",
+    ")\n",
+    "\n",
+    "fig2.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### topogenes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/binglun/miniconda3/envs/totopos/lib/python3.13/site-packages/dreimac/emcoords.py:179: UserWarning: There are 17427 point not covered by a landmark\n",
+      "  warnings.warn(\"There are {} point not covered by a landmark\".format(nzero))\n"
+     ]
+    }
+   ],
+   "source": [
+    "import totopos.genes as tpg\n",
+    "\n",
+    "coords = tpg.get_circular_coords(\n",
+    "    topological_loops,\n",
+    "    loop_index=0,\n",
+    "    n_dim=None,        # use all features of that loop\n",
+    "    plot=False,         # if you want to see the persistence diagram\n",
+    "    n_landmarks=1000,\n",
+    "    prime=47,\n",
+    "    cocycle_idx=0,\n",
+    "    standard_range=False\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scores, feat_order = tpg.topo_scores_rep_sampling(\n",
+    "    adata,\n",
+    "    topological_loops,\n",
+    "    coords,\n",
+    "    loop_index=0,\n",
+    "    n_reps=100,\n",
+    "    frac_rep=0.2,\n",
+    "    seed=42\n",
+    ")\n",
+    "# `scores[i]` is the importance of feature i, and `feat_order` lists feature indices\n",
+    "# from most→least important."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Top 20 genes: ['Robo2', 'Unc5c', 'Kif26b', 'Kcnh7', 'Pcdh7', 'Epha5', 'Smoc1', 'Cdh11', 'Slit2', 'Sox6', 'Tshz2', 'Cacna2d1', 'Ebf1', 'Nrp1', 'Nkain3', 'Kcnq5', 'H19', 'Foxp2', 'Sdk1', 'Frem1']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Suppose `scores, sorted_idx = compute_topo_gradient_scores(...)`\n",
+    "top20 = tpg.get_topogenes(adata, feat_order, n_genes=20, gene_name_col='gene_name')\n",
+    "print(\"Top 20 genes:\", top20)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "totopos",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/totopos/__init__.py
+++ b/totopos/__init__.py
@@ -6,3 +6,4 @@ __email__ = """manuflores@caltech.edu"""
 __version__ = """0.0.1"""
 
 from . import pseudotime
+from . import cells

--- a/totopos/cells/__init__.py
+++ b/totopos/cells/__init__.py
@@ -1,1 +1,2 @@
 from .critical import *
+from .preprocess import *

--- a/totopos/cells/critical.py
+++ b/totopos/cells/critical.py
@@ -258,7 +258,7 @@ def critical_edge_method(
 
     if ph == None:
         if verbose: print("Starting de novo PH computation...")
-        if npts > data.shape[0]:
+        if npts is not None and npts > data.shape[0]:
             npts = None  # Use all points if npts is larger than the number of points in data
         ph = ripser(data, do_cocycles=True, n_perm=npts)
         if verbose:print("Finished computing PH.")

--- a/totopos/cells/critical.py
+++ b/totopos/cells/critical.py
@@ -282,15 +282,18 @@ def critical_edge_method(
         if verbose:print(f"Starting {i+1}-th loop discovery...")
         _, topological_loop = prim_tree_find_loop(one_skeleton, crit_edge_sub, points)
         if verbose:print(f"Finished computing loop {i+1} from VR graph.")
+        topological_loop = [
+            (sub2full[edge[0]], sub2full[edge[1]]) for edge in topological_loop
+        ]
         topological_loop_data[i]["loop"] = topological_loop
 
         if compute_topocells:
             zero_sk = np.unique(topological_loop)
-            zero_sk_full = np.array([sub2full[ix] for ix in zero_sk])
+            # zero_sk_full = np.array([sub2full[ix] for ix in zero_sk])
 
             topocells, tpc_ixs = get_loop_neighbors(
                 all_data = data,
-                query_data = data[zero_sk_full],
+                query_data = data[zero_sk],
                 radius = birth_dist,
             )
 

--- a/totopos/cells/critical.py
+++ b/totopos/cells/critical.py
@@ -289,7 +289,6 @@ def critical_edge_method(
 
         if compute_topocells:
             zero_sk = np.unique(topological_loop)
-            # zero_sk_full = np.array([sub2full[ix] for ix in zero_sk])
 
             topocells, tpc_ixs = get_loop_neighbors(
                 all_data = data,

--- a/totopos/cells/critical.py
+++ b/totopos/cells/critical.py
@@ -30,65 +30,58 @@ def prim_tree_find_loop(graph: nx.Graph, critical_edge: tuple, points: np.ndarra
     for start_vertex in [u_edge, v_edge]:
         if start_vertex not in graph:
             continue
-        # Get all edges from the start vertex, sorted by weight
-        edges_from_start = sorted(graph[start_vertex], key=lambda x: graph[start_vertex][x]['weight'])
         
-        # Try each edge from the start vertex
-        for smallest_neighbor in edges_from_start:
-            # Initialize for each attempt
-            mst_edges = []
-            visited = set()
-            priority_queue = []
+        mst_edges = []
+        visited = set([start_vertex])
+        priority_queue = []
 
-            # Force the starting vertex to have degree 1 with current edge
-            visited.add(start_vertex)
-            mst_edges.append((start_vertex, smallest_neighbor, graph[start_vertex][smallest_neighbor]['weight']))
-            visited.add(smallest_neighbor)
+        # Add edges from the start vertex to the priority queue, excluding the critical edge
+        for neighbor in graph[start_vertex]:
+            if neighbor not in visited:
+                # Exclude the critical edge from the MST building phase
+                if not ((start_vertex == u_edge and neighbor == v_edge) or (start_vertex == v_edge and neighbor == u_edge)):
+                    weight = graph[start_vertex][neighbor]['weight']
+                    heapq.heappush(priority_queue, (weight, start_vertex, neighbor))
 
-            # Add edges from the chosen neighbor (not the start vertex) to the queue
-            for neighbor in graph[smallest_neighbor]:
-                if neighbor not in visited:
-                    weight = graph[smallest_neighbor][neighbor]['weight']
-                    heapq.heappush(priority_queue, (weight, smallest_neighbor, neighbor))
+        # Grow the tree for the remaining vertices
+        while priority_queue:
+            weight, u, v = heapq.heappop(priority_queue)
+            if v not in visited:
+                # Add the edge to the tree
+                mst_edges.append((u, v, weight))
+                visited.add(v)
 
-            # Grow the tree for the remaining vertices
-            while priority_queue:
-                weight, u, v = heapq.heappop(priority_queue)
-                if v not in visited:
-                    # Add the edge to the tree
-                    mst_edges.append((u, v, weight))
-                    visited.add(v)
-
-                    # Add edges from the new vertex to the priority queue
-                    for neighbor in graph[v]:
-                        if neighbor not in visited:
+                # Add edges from the new vertex to the priority queue
+                for neighbor in graph[v]:
+                    if neighbor not in visited:
+                        if not ((v == u_edge and neighbor == v_edge) or (v == v_edge and neighbor == u_edge)):
                             weight = graph[v][neighbor]['weight']
                             heapq.heappush(priority_queue, (weight, v, neighbor))
 
-            # After building the tree, check if adding the critical edge forms a cycle using NetworkX
-            # Build the graph using NetworkX
-            G = nx.Graph()
-            G.add_weighted_edges_from(mst_edges)
+        # After building the tree, check if adding the critical edge forms a cycle using NetworkX
+        # Build the graph using NetworkX
+        G = nx.Graph()
+        G.add_weighted_edges_from(mst_edges)
 
-            # Check if both nodes of the critical edge are in the tree
-            if u_edge in G.nodes and v_edge in G.nodes:
-                # Add the critical edge with weight calculated from points
-                weight_edge = np.linalg.norm(points[u_edge] - points[v_edge])
-                G.add_edge(u_edge, v_edge, weight=weight_edge)
-                try:
-                    # Attempt to find a cycle starting from u_edge
-                    cycle = nx.find_cycle(G, source=u_edge)
-                    cycle = np.array(cycle)
-                    # print(f"Cycle formed after adding critical edge {edge} starting from vertex '{start_vertex}':")
-                    # print("Cycle:", cycle)
-                    # Return the MST edges plus the critical edge
-                    return mst_edges, cycle
-                except nx.exception.NetworkXNoCycle:
-                    # No cycle formed, continue to next edge
-                    pass
-            else:
-                # Critical edge nodes not in tree, cannot form cycle
+        # Check if both nodes of the critical edge are in the tree
+        if u_edge in G.nodes and v_edge in G.nodes:
+            # Add the critical edge with weight calculated from points
+            weight_edge = np.linalg.norm(points[u_edge] - points[v_edge])
+            G.add_edge(u_edge, v_edge, weight=weight_edge)
+            try:
+                # Attempt to find a cycle starting from u_edge
+                cycle = nx.find_cycle(G, source=u_edge)
+                cycle = np.array(cycle)
+                # print(f"Cycle formed after adding critical edge {edge} starting from vertex '{start_vertex}':")
+                # print("Cycle:", cycle)
+                # Return the MST edges plus the critical edge
+                return mst_edges, cycle
+            except nx.exception.NetworkXNoCycle:
+                # No cycle formed, continue to next edge
                 pass
+        else:
+            # Critical edge nodes not in tree, cannot form cycle
+            pass
 
             # If no cycle is formed, or critical edge nodes are not in tree, backtrack and try next edge
         # If no valid tree is found with the current starting vertex, continue to the next starting vertex
@@ -227,7 +220,7 @@ def get_loop_neighbors(all_data: np.ndarray, query_data: np.ndarray, radius: flo
     return topocells, unique_inds
 
 def critical_edge_method(
-    data:np.ndarray, ph:dict=None, n_loops:int = 1, verbose:bool=False, method:str = "ripser", compute_topocells:bool=True
+    data:np.ndarray, ph:dict=None, npts:int=None, n_loops:int = 1, verbose:bool=False, method:str = "ripser", compute_topocells:bool=True
     )->list: 
     """
     Returns a list homology data for `n_loops` with largest lifetimes in Dgm_1(data). 
@@ -239,6 +232,9 @@ def critical_edge_method(
     
     ph (dict, optional)
         Precomputed PH output from ripser. If None, program will compute PH from scratch.
+
+    npts (int, optional)
+        Number of points to use for calculation. If None, all points will be used.
     
     n_loops(int)
 
@@ -262,30 +258,39 @@ def critical_edge_method(
 
     if ph == None:
         if verbose: print("Starting de novo PH computation...")
-        ph = ripser(data, do_cocycles=True)
+        if npts > data.shape[0]:
+            npts = None  # Use all points if npts is larger than the number of points in data
+        ph = ripser(data, do_cocycles=True, n_perm=npts)
         if verbose:print("Finished computing PH.")
 
+    idx_perm = ph['idx_perm'] if 'idx_perm' in ph else np.arange(data.shape[0])
+    points = data[idx_perm]
+    full2sub = {full:sub for sub, full in enumerate(idx_perm)}
+    sub2full = {sub:full for sub, full in enumerate(idx_perm)}
+
     topological_loop_data = get_prominent_cohomology_class_data(ph,n=n_loops, method=method)
+    birth_dist_latest = topological_loop_data[0]["birth_dist"]
+    if verbose:print("Starting VR graph construction.")
+    one_skeleton = vietoris_rips_graph(points, birth_dist_latest)
+    if verbose:print(f"Finished VR graph. Starting loop discovery...")
 
     iterable = range(n_loops) if n_loops==1 else tqdm(range(n_loops))
-    
     for i in iterable:
         birth_dist=topological_loop_data[i]["birth_dist"]
         crit_edge=topological_loop_data[i]["critical_edge"]
-        if verbose:print("Starting VR graph construction.")
-        one_skeleton = vietoris_rips_graph(data, birth_dist)
-        if verbose:print(f"Finished VR graph. Starting {i+1}-th loop discovery...")
-        _, topological_loop = prim_tree_find_loop(one_skeleton, crit_edge, data)
-        if verbose:print("Finished computing loop from VR graph.")
-        topological_loop = np.array(topological_loop)
+        crit_edge_sub = (full2sub[crit_edge[0]], full2sub[crit_edge[1]])
+        if verbose:print(f"Starting {i+1}-th loop discovery...")
+        _, topological_loop = prim_tree_find_loop(one_skeleton, crit_edge_sub, points)
+        if verbose:print(f"Finished computing loop {i+1} from VR graph.")
         topological_loop_data[i]["loop"] = topological_loop
 
         if compute_topocells:
             zero_sk = np.unique(topological_loop)
+            zero_sk_full = np.array([sub2full[ix] for ix in zero_sk])
 
             topocells, tpc_ixs = get_loop_neighbors(
                 all_data = data,
-                query_data = data[zero_sk],
+                query_data = data[zero_sk_full],
                 radius = birth_dist,
             )
 

--- a/totopos/cells/preprocess.py
+++ b/totopos/cells/preprocess.py
@@ -49,7 +49,6 @@ def find_pca_cutoff(adata, thres=0.02, k=100, save_pca=True):
 
     return cutoff_pc
 
-import numpy as np
 import matplotlib.pyplot as plt
 from sklearn.ensemble import IsolationForest
 from sklearn.preprocessing import StandardScaler

--- a/totopos/cells/preprocess.py
+++ b/totopos/cells/preprocess.py
@@ -108,7 +108,9 @@ def detect_outliers(adata, n_pcs=50, contamination=0.05, max_samples=100000,
     
     outlier_mask = predictions == -1
     
-    print(f"Found {np.sum(outlier_mask):,} outliers ({100*np.sum(outlier_mask)/len(outlier_mask):.1f}%)")
+    import logging
+    logger = logging.getLogger(__name__)
+    logger.info(f"Found {np.sum(outlier_mask):,} outliers ({100*np.sum(outlier_mask)/len(outlier_mask):.1f}%)")
     
     return outlier_mask, scores
 

--- a/totopos/cells/preprocess.py
+++ b/totopos/cells/preprocess.py
@@ -1,0 +1,177 @@
+import numpy as np
+from scipy.sparse import linalg as sla
+
+def find_pca_cutoff(adata, thres=0.02, k=100, save_pca=True):
+    """
+    Find the optimal number of principal components based on explained variance gaps.
+    
+    Parameters:
+    -----------
+    adata : AnnData object
+        Annotated data object containing the expression matrix
+    thres : float, default=0.02
+        Threshold parameter for gap detection (typically between 0 and 1)
+    k : int, default=100
+        Number of singular values to compute
+    
+    Returns:
+    --------
+    cutoff_pc : int
+        The recommended number of principal components to retain
+    """
+    
+    # Center the data
+    X_cen = adata.X - adata.X.mean(axis=0)
+    
+    # Perform SVD
+    U, s, Vt = sla.svds(X_cen, k=k)
+    ix_sort = np.argsort(s)[::-1]
+    U, s, Vt = U[:, ix_sort], s[ix_sort], Vt[ix_sort, :]
+    explained_variance_ratio = s**2
+
+    # Find gaps between consecutive components
+    gaps = explained_variance_ratio[:-1] - explained_variance_ratio[1:]
+    
+    # Apply threshold
+    gap_threshold = thres * explained_variance_ratio[:-1]
+    below_thresh = np.where(gaps < gap_threshold)[0]
+    
+    # Determine cutoff
+    cutoff_pc = below_thresh[0] + 1 if len(below_thresh) > 0 else k
+    
+    if save_pca:
+        pcs = U*s
+        adata.obsm['pcs'] = pcs
+        adata.obs['pc1'] = pcs[:, 0]
+        adata.obs['pc2'] = pcs[:, 1]
+        adata.obs['pc3'] = pcs[:, 2]
+        adata.obs['pc4'] = pcs[:, 3]
+
+    return cutoff_pc
+
+import numpy as np
+import matplotlib.pyplot as plt
+from sklearn.ensemble import IsolationForest
+from sklearn.preprocessing import StandardScaler
+
+def detect_outliers(adata, n_pcs=50, contamination=0.05, max_samples=100000, 
+                    n_jobs=-1, n_estimators=100, random_state=42):
+    """
+    Detect outliers using Isolation Forest on PCA data.
+    
+    Parameters:
+    -----------
+    adata : AnnData
+        Data with PCA in adata.obsm['X_pca'] or adata.obsm['pca']
+    n_pcs : int, default=50
+        Number of PCs to use
+    contamination : float, default=0.05
+        Expected fraction of outliers
+    max_samples : int, default=100000
+        Subsample size for tree building
+    
+    Returns:
+    --------
+    outlier_mask : array
+        Boolean mask (True = outlier)
+    outlier_scores : array
+        Anomaly scores (more negative = more anomalous)
+    """
+    
+    # Get PCA data
+    if 'X_pca' in adata.obsm:
+        pca_data = adata.obsm['X_pca']
+    elif 'pca' in adata.obsm:
+        pca_data = adata.obsm['pca']
+    elif 'pcs' in adata.obsm:
+        pca_data = adata.obsm['pcs']
+    else:
+        raise ValueError("No PCA found. Run sc.pp.pca() first.")
+    
+    # Use specified number of PCs
+    features = pca_data[:, :n_pcs]
+    
+    # Standardize features
+    scaler = StandardScaler()
+    features_scaled = scaler.fit_transform(features)
+    
+    # Fit Isolation Forest
+    clf = IsolationForest(
+        n_estimators=n_estimators,
+        max_samples=min(max_samples, len(features)),
+        contamination=contamination,
+        random_state=random_state,
+        n_jobs=n_jobs
+    )
+    
+    predictions = clf.fit_predict(features_scaled)
+    scores = clf.score_samples(features_scaled)
+    
+    outlier_mask = predictions == -1
+    
+    print(f"Found {np.sum(outlier_mask):,} outliers ({100*np.sum(outlier_mask)/len(outlier_mask):.1f}%)")
+    
+    return outlier_mask, scores
+
+def plot_outliers(adata, outlier_mask, outlier_scores):
+    """
+    Simple visualization of outlier detection results.
+    """
+    
+    # Get PCA coordinates
+    if 'X_pca' in adata.obsm:
+        pca = adata.obsm['X_pca']
+    elif 'pca' in adata.obsm:
+        pca = adata.obsm['pca']
+    elif 'pcs' in adata.obsm:
+        pca = adata.obsm['pcs']
+    else:
+        raise ValueError("No PCA found. Run sc.pp.pca() first.")
+    
+    fig, axes = plt.subplots(1, 3, figsize=(15, 4))
+    
+    # Plot 1: PCA with outliers highlighted
+    normal = ~outlier_mask
+    axes[0].scatter(pca[normal, 0], pca[normal, 1], c='lightblue', s=1, alpha=0.6, label='Normal')
+    axes[0].scatter(pca[outlier_mask, 0], pca[outlier_mask, 1], c='red', s=3, alpha=0.8, label='Outliers')
+    axes[0].set_xlabel('PC1')
+    axes[0].set_ylabel('PC2')
+    axes[0].legend()
+    axes[0].set_title('Outliers in PC Space')
+    
+    # Plot 2: Score distribution
+    axes[1].hist(outlier_scores[normal], bins=50, alpha=0.7, label='Normal', color='lightblue')
+    axes[1].hist(outlier_scores[outlier_mask], bins=20, alpha=0.8, label='Outliers', color='red')
+    axes[1].set_xlabel('Anomaly Score')
+    axes[1].set_ylabel('Count')
+    axes[1].legend()
+    axes[1].set_title('Score Distribution')
+    
+    # Plot 3: QC comparison (if available)
+    if 'total_counts' in adata.obs.columns:
+        axes[2].boxplot([adata.obs.loc[normal, 'total_counts'], 
+                        adata.obs.loc[outlier_mask, 'total_counts']], 
+                       labels=['Normal', 'Outliers'])
+        axes[2].set_ylabel('Total Counts')
+        axes[2].set_yscale('log')
+        axes[2].set_title('Total Counts')
+    else:
+        axes[2].text(0.5, 0.5, 'No QC metrics\navailable', ha='center', va='center')
+        axes[2].set_title('QC Metrics')
+    
+    plt.tight_layout()
+    plt.show()
+
+# Simple usage example:
+"""
+# Detect outliers
+outlier_mask, scores = detect_outliers(adata, n_pcs=50, contamination=0.05)
+
+# Visualize results
+plot_outliers(adata, outlier_mask, scores)
+
+# Add to adata and filter
+adata.obs['is_outlier'] = outlier_mask
+adata.obs['outlier_score'] = scores
+adata_clean = adata[~outlier_mask].copy()
+"""

--- a/totopos/genes/__init__.py
+++ b/totopos/genes/__init__.py
@@ -1,1 +1,2 @@
 from .perturb_ripser import *
+from .rep_sampling import *

--- a/totopos/genes/rep_sampling.py
+++ b/totopos/genes/rep_sampling.py
@@ -1,0 +1,204 @@
+from dreimac import CircularCoords
+from persim import plot_diagrams
+import numpy as np
+
+def get_circular_coords(
+    topological_loops,
+    loop_index: int = 0,
+    n_dim: int = None,
+    plot: bool = False,
+    n_landmarks: int = 1000,
+    prime: int = 47,
+    cocycle_idx: int = 0,
+    standard_range: bool = False
+):
+    """
+    Compute (and optionally plot) circular coordinates for a given loop in `topological_loops`.
+
+    Parameters
+    ----------
+    topological_loops : list of dict
+        Each dict must contain a 'topocells' key holding an array-like shape (n_samples, n_features).
+    loop_index : int, default=0
+        Which entry of `topological_loops` to use.
+    n_dim : int, optional
+        Number of leading dimensions (columns) to retain from the extracted topocells.
+        If None, uses all columns.
+    plot : bool, default=False
+        If True, calls plot_diagrams on the persistence diagrams.
+    n_landmarks : int, default=1000
+        Number of landmarks for CircularCoords.
+    prime : int, default=47
+        Prime for finite-field arithmetic.
+    cocycle_idx : int, default=0
+        Which cocycle to extract coordinates from.
+    standard_range : bool, default=False
+        If True, rescales coords to [0,1]; otherwise returns raw angles.
+
+    Returns
+    -------
+    circ_coord : ndarray, shape (n_samples,)
+        The circular coordinate for each sample in the chosen loop.
+    """
+    # extract the topocells for this loop
+    try:
+        topocells = np.asarray(topological_loops[loop_index]['topocells'])
+    except (IndexError, KeyError, TypeError):
+        raise ValueError(f"Could not extract 'topocells' from loop_index={loop_index}")
+
+    # validate shape
+    if topocells.ndim != 2:
+        raise ValueError(f"Expected 2D array, got shape {topocells.shape}")
+
+    # determine how many dimensions to keep
+    max_dim = topocells.shape[1]
+    if n_dim is None:
+        n_dim = max_dim
+    if not isinstance(n_dim, int) or n_dim < 1 or n_dim > max_dim:
+        raise ValueError(f"`n_dim` must be an integer in [1, {max_dim}], got {n_dim}")
+
+    # slice off the first n_dim columns
+    X = topocells[:, :n_dim]
+
+    # build and (optionally) plot
+    cc = CircularCoords(X, n_landmarks=n_landmarks, prime=prime)
+    if plot:
+        plot_diagrams(cc.dgms_)
+
+    # compute & return
+    return cc.get_coordinates(cocycle_idx=cocycle_idx, standard_range=standard_range)
+
+import torch
+
+def topo_scores_rep_sampling(
+    adata,
+    topological_loops,
+    coords,
+    loop_index: int = 0,
+    n_reps: int = 100,
+    frac_rep: float = 0.2,
+    seed: int = 0,
+):
+    """
+    Compute feature-importance scores via gradients of a topological loop loss.
+
+    Parameters
+    ----------
+    adata : AnnData
+        Your AnnData object whose .X is (n_cells × n_features).
+    topological_loops : list of dict
+        Each entry must have a 'topocell_ixs' key giving a list/array of cell indices.
+    coords : array‐like, shape (n_cells_total,)
+        Circular coordinate value for each cell (e.g. output of get_circular_coords).
+    loop_index : int, default=0
+        Which loop in `topological_loops` to use.
+    n_reps : int, default=100
+        How many random subsamples to average over.
+    frac_rep : float ∈ (0,1], default=0.2
+        Fraction of the loop’s cells to sample each repetition.
+    seed : int, default=0
+        RNG seed for reproducibility.
+
+    Returns
+    -------
+    scores : ndarray, shape (n_features,)
+        L2-norm of the gradient w.r.t. each feature.
+    sorted_indices : ndarray, shape (n_features,)
+        Indices of features sorted by descending `scores`.
+    """
+    # --- validate & extract the relevant cells ----------------
+    try:
+        topocell_ixs = topological_loops[loop_index]['topocell_ixs']
+    except (IndexError, KeyError, TypeError):
+        raise ValueError(f"Could not get 'topocell_ixs' from loop index {loop_index}")
+    
+    # convert adata.X to a dense NumPy array if needed
+    X_full = adata.X.toarray() if hasattr(adata.X, "toarray") else np.asarray(adata.X)
+    topocells_full = X_full[topocell_ixs, :]  # (n_loop_cells × n_features)
+
+    # --- set seeds and build torch tensor ---------------------
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    pts = torch.tensor(topocells_full, dtype=torch.float32, requires_grad=True)
+
+    # --- accumulate topological‐loss over random subsamples ----
+    topo_loss_total = torch.tensor(0.0, dtype=torch.float32)
+    n_loop = pts.shape[0]
+    coords = np.asarray(coords)
+    if coords.shape[0] != topocells_full.shape[0]:
+        raise ValueError("`coords` length must match number of cells in `adata`")
+
+    for _ in range(n_reps):
+        # how many loop‐cells to pick
+        n_cells = torch.randint(
+            low=1, high=int(frac_rep * n_loop) + 1, size=(1,)
+        ).item()
+        perm = torch.randperm(n_loop)[:n_cells]
+        rep_pts = pts[perm]                      # (n_cells × n_features)
+        
+        # order them by their circular‐coordinate
+        cc_vals = coords[perm.numpy()]
+        order = np.argsort(cc_vals)
+        rep_pts = rep_pts[torch.LongTensor(order)]
+        
+        # close the loop and sum edge‐lengths
+        closed = torch.cat([rep_pts, rep_pts[0:1]], dim=0)
+        diffs = closed[1:] - closed[:-1]
+        topo_loss_total = topo_loss_total + diffs.norm(dim=1).sum()
+
+    # --- backprop & extract feature scores -------------------
+    topo_loss_total.backward()
+    grad = pts.grad                          # (n_loop × n_features)
+    scores = grad.norm(dim=0).cpu().numpy()  # (n_features,)
+    sorted_indices = np.argsort(scores)[::-1]
+
+    return scores, sorted_indices
+
+
+def get_topogenes(
+    adata,
+    feat_order,
+    n_genes: int = 20,
+    gene_name_col: str = 'gene_name'
+) -> list:
+    """
+    Retrieve the top gene names from an AnnData object based on a list of
+    feature indices sorted by importance.
+
+    Parameters
+    ----------
+    adata : AnnData
+        Annotated data matrix whose .var DataFrame contains gene metadata.
+    feat_order : array-like of int
+        Array of feature indices, typically sorted descending by importance
+        (e.g. output of compute_topo_gradient_scores).
+    n_genes : int, default=20
+        Number of top genes to return.
+    gene_name_col : str, default='gene_name'
+        Column name in `adata.var` that holds the gene names.
+
+    Returns
+    -------
+    topogenes : list of str
+        The names of the top `n_genes` features.
+    """
+    # Validate inputs
+    if not hasattr(adata, 'var'):
+        raise ValueError("`adata` must be an AnnData with a .var DataFrame")
+    if gene_name_col not in adata.var.columns:
+        raise KeyError(f"`gene_name_col` '{gene_name_col}' not found in adata.var.columns")
+
+    feat_order = np.asarray(feat_order, dtype=int)
+    if feat_order.ndim != 1:
+        raise ValueError("`feat_order` must be a one-dimensional array of feature indices")
+    if n_genes < 1 or n_genes > feat_order.size:
+        raise ValueError(f"`n_genes` must be between 1 and {feat_order.size}, got {n_genes}")
+
+    # Select the top indices
+    top_indices = feat_order[:n_genes]
+
+    # Retrieve gene names
+    # Use .iloc in case var is not ordered by feature index
+    gene_names = adata.var[gene_name_col].iloc[top_indices].tolist()
+
+    return gene_names

--- a/totopos/viz/cloud.py
+++ b/totopos/viz/cloud.py
@@ -673,3 +673,407 @@ def make_inset_axis_label(ax, xlabel="PC 1", ylabel="PC 2"):
     inset_ax.spines['left'].set_linewidth(0.8)
     inset_ax.spines['bottom'].set_linewidth(0.8)
     inset_ax.set_facecolor('none')
+
+
+import pandas as pd
+import numpy as np
+import plotly.graph_objects as go
+
+def plot_topocells_highlighted(
+    adata, 
+    topological_loops,
+    loop_indices=None,
+    title=None, 
+    pcs_viz=(1, 2, 3), 
+    color_col=None, 
+    hover_cols=None, 
+    white_background=True,
+    palette_topocells=None,
+    dot_size_gray=1,
+    dot_size_topo=2,
+    gray_alpha=0.3,
+    topo_alpha=0.5,
+    use_pca=True,
+    show_loops=False,
+    line_width=2
+):
+    """
+    Plot single-cell data with topocells highlighted in color and rest in gray.
+
+    Parameters
+    ----------
+    adata : AnnData
+        Annotated data object containing single-cell data
+    topological_loops : list of dict
+        List of dictionaries containing loop information with keys:
+        - 'topocell_ixs': array of indices for topologically important cells
+        - 'loop': list of tuples representing edges (if show_loops=True)
+        - 'birth_dist': birth time (if show_loops=True)
+        - 'pers': persistence (if show_loops=True)
+    loop_indices : list of int, optional
+        Which loops to highlight (default: all loops)
+    title : str, optional
+        Title of the plot
+    pcs_viz : tuple, optional
+        Indices of principal components to visualize (default: (0, 1, 2))
+    color_col : str, optional
+        Column name in adata.obs for coloring topocells
+    hover_cols : list, optional
+        List of column names from adata.obs to include in hover info
+    white_background : bool, optional
+        Whether to use white background (default: True)
+    palette_topocells : list, optional
+        Custom color palette for different loops' topocells
+    dot_size_gray : int, optional
+        Size of gray background points (default: 2)
+    dot_size_topo : int, optional
+        Size of highlighted topocells (default: 4)
+    gray_alpha : float, optional
+        Opacity of gray background points (default: 0.3)
+    topo_alpha : float, optional
+        Opacity of highlighted topocells (default: 0.8)
+    use_pca : bool, optional
+        Whether to use PCA coordinates from adata.obsm['pcs'] (default: True)
+    show_loops : bool, optional
+        Whether to also show the loop connections (default: False)
+    line_width : int, optional
+        Width of loop lines if show_loops=True (default: 3)
+
+    Returns
+    -------
+    plotly.graph_objects.Figure
+        Interactive 3D plot with topocells highlighted
+    """
+    
+    # Default color palette for different loops
+    if palette_topocells is None:
+        palette_topocells = [
+            "#e41a1c", "#377eb8", "#4daf4a", "#984ea3", "#ff7f00", 
+            "#ffff33", "#a65628", "#f781bf", "#66c2a5", "#fc8d62",
+            "#8da0cb", "#e78ac3", "#a6d854", "#ffd92f", "#e5c494"
+        ]
+    
+    # Determine which loops to show
+    if loop_indices is None:
+        loop_indices = list(range(len(topological_loops)))
+    
+    # Get PCA coordinates
+    if use_pca and 'pcs' in adata.obsm:
+        pca_coords = adata.obsm['pcs']
+        n_pcs = min(pca_coords.shape[1], max(pcs_viz) + 1)
+        pc_columns = [f"pc{i}" for i in range(n_pcs)]
+        data_df = pd.DataFrame(pca_coords[:, :n_pcs], columns=pc_columns)
+        
+        # Add obs data
+        for col in adata.obs.columns:
+            data_df[col] = adata.obs[col].values
+    else:
+        raise ValueError("use_pca=False not implemented for this function. Use PCA coordinates.")
+    
+    # Set coordinate columns
+    x_col = f"pc{pcs_viz[0]}"
+    y_col = f"pc{pcs_viz[1]}"  
+    z_col = f"pc{pcs_viz[2]}"
+    
+    # Create hover text for all cells
+    hover_text = None
+    if hover_cols:
+        available_hover_cols = [col for col in hover_cols if col in data_df.columns]
+        if available_hover_cols:
+            hover_text = data_df[available_hover_cols].apply(
+                lambda row: '<br>'.join([f"{col}: {row[col]}" for col in available_hover_cols]),
+                axis=1
+            )
+    
+    # Collect all topocell indices
+    all_topocell_indices = set()
+    loop_topocell_mapping = {}
+    
+    for loop_idx in loop_indices:
+        if loop_idx < len(topological_loops):
+            loop_info = topological_loops[loop_idx]
+            if 'topocell_ixs' in loop_info:
+                topocells = set(loop_info['topocell_ixs'])
+                all_topocell_indices.update(topocells)
+                loop_topocell_mapping[loop_idx] = topocells
+    
+    # Create mask for topocells
+    is_topocell = np.zeros(len(data_df), dtype=bool)
+    topocell_loop_assignment = np.full(len(data_df), -1, dtype=int)
+    
+    for loop_idx, topocells in loop_topocell_mapping.items():
+        for idx in topocells:
+            if idx < len(data_df):
+                is_topocell[idx] = True
+                if topocell_loop_assignment[idx] == -1:  # First assignment wins
+                    topocell_loop_assignment[idx] = loop_idx
+    
+    traces = []
+    
+    # 1. Gray background trace (all non-topocells)
+    gray_mask = ~is_topocell
+    if np.any(gray_mask):
+        gray_hover = hover_text[gray_mask] if hover_text is not None else None
+        
+        gray_trace = go.Scatter3d(
+            x=data_df[gray_mask][x_col],
+            y=data_df[gray_mask][y_col], 
+            z=data_df[gray_mask][z_col],
+            mode='markers',
+            marker=dict(
+                size=dot_size_gray,
+                color='lightgray',
+                opacity=gray_alpha,
+                line=dict(width=0)
+            ),
+            text=gray_hover,
+            hoverinfo='text' if gray_hover is not None else 'x+y+z',
+            name='Background cells',
+            showlegend=True
+        )
+        traces.append(gray_trace)
+    
+    # 2. Colored traces for each loop's topocells
+    for i, loop_idx in enumerate(loop_indices):
+        if loop_idx not in loop_topocell_mapping:
+            continue
+            
+        # Create mask for this loop's topocells
+        loop_mask = (topocell_loop_assignment == loop_idx)
+        
+        if not np.any(loop_mask):
+            continue
+        
+        # Get color for topocells
+        if color_col and color_col in data_df.columns:
+            # Use the specified column for coloring
+            color_values = data_df[loop_mask][color_col]
+            if hasattr(color_values, 'cat'):
+                color_values = color_values.astype(str)
+            marker_color = color_values
+            colorscale = 'Viridis'  # Default colorscale
+        else:
+            # Use loop-specific color
+            marker_color = palette_topocells[i % len(palette_topocells)]
+            colorscale = None
+        
+        loop_hover = hover_text[loop_mask] if hover_text is not None else None
+        
+        # Get loop info for name
+        loop_info = topological_loops[loop_idx]
+        birth_time = float(loop_info.get('birth_dist', 0))
+        persistence = float(loop_info.get('pers', 0))
+        n_topocells = np.sum(loop_mask)
+        
+        topocell_trace = go.Scatter3d(
+            x=data_df[loop_mask][x_col],
+            y=data_df[loop_mask][y_col], 
+            z=data_df[loop_mask][z_col],
+            mode='markers',
+            marker=dict(
+                size=dot_size_topo,
+                color=marker_color,
+                colorscale=colorscale,
+                opacity=topo_alpha,
+                line=dict(width=0, color='white')
+            ),
+            text=loop_hover,
+            hoverinfo='text' if loop_hover is not None else 'x+y+z',
+            name=f'Loop {loop_idx+1} ({n_topocells} cells, B:{birth_time:.2f}, P:{persistence:.2f})',
+            showlegend=True
+        )
+        traces.append(topocell_trace)
+        
+        # 3. Add loop connections if requested
+        if show_loops and 'loop' in loop_info:
+            loop_edges = loop_info['loop']
+            topocells_set = loop_topocell_mapping[loop_idx]
+            
+            # Build coordinates for the loop connections
+            x_coords = []
+            y_coords = []
+            z_coords = []
+            
+            for edge in loop_edges:
+                start_idx = int(edge[0])
+                end_idx = int(edge[1])
+                
+                if (start_idx in topocells_set and end_idx in topocells_set and
+                    start_idx < len(data_df) and end_idx < len(data_df)):
+                    
+                    x_coords.extend([data_df.iloc[start_idx][x_col], data_df.iloc[end_idx][x_col], None])
+                    y_coords.extend([data_df.iloc[start_idx][y_col], data_df.iloc[end_idx][y_col], None])  
+                    z_coords.extend([data_df.iloc[start_idx][z_col], data_df.iloc[end_idx][z_col], None])
+            
+            if len(x_coords) > 0:
+                loop_trace = go.Scatter3d(
+                    x=x_coords,
+                    y=y_coords,
+                    z=z_coords,
+                    mode='lines',
+                    line=dict(
+                        color=palette_topocells[i % len(palette_topocells)], 
+                        width=line_width
+                    ),
+                    name=f'Loop {loop_idx+1} connections',
+                    hoverinfo='name',
+                    showlegend=False  # Don't clutter legend
+                )
+                traces.append(loop_trace)
+    
+    # Create figure
+    fig = go.Figure(data=traces)
+    
+    # Update layout
+    n_topocells_total = len(all_topocell_indices)
+    n_background = len(data_df) - n_topocells_total
+    
+    layout_kwargs = {
+        'title': title or f'Topocells Highlighted ({n_topocells_total} topocells, {n_background} background)',
+        'showlegend': True,
+        'width': 1000,
+        'height': 800,
+        'scene': dict(
+            xaxis_title=f'PC{pcs_viz[0]}',
+            yaxis_title=f'PC{pcs_viz[1]}', 
+            zaxis_title=f'PC{pcs_viz[2]}',
+            camera=dict(
+                eye=dict(x=1.5, y=1.5, z=1.5)
+            )
+        )
+    }
+    
+    if white_background:
+        layout_kwargs.update({
+            'plot_bgcolor': 'white',
+            'paper_bgcolor': 'white'
+        })
+        layout_kwargs['scene'].update({
+            'xaxis': dict(backgroundcolor='white', gridcolor='lightgray'),
+            'yaxis': dict(backgroundcolor='white', gridcolor='lightgray'),
+            'zaxis': dict(backgroundcolor='white', gridcolor='lightgray')
+        })
+    
+    fig.update_layout(**layout_kwargs)
+    
+    return fig
+
+
+def plot_single_loop_topocells(
+    adata, 
+    topological_loops,
+    loop_index,
+    title=None,
+    pcs_viz=(1, 2, 3), 
+    color_col=None,
+    hover_cols=None,
+    **kwargs
+):
+    """
+    Convenience function to plot topocells from a single loop.
+    
+    Parameters
+    ----------
+    adata : AnnData
+        Annotated data object
+    topological_loops : list of dict
+        Loop information
+    loop_index : int
+        Index of the loop to highlight
+    title : str, optional
+        Plot title
+    pcs_viz : tuple, optional
+        PC indices to plot
+    color_col : str, optional
+        Column for coloring topocells
+    hover_cols : list, optional
+        Columns for hover info
+    **kwargs
+        Additional arguments passed to plot_topocells_highlighted
+    
+    Returns
+    -------
+    plotly.graph_objects.Figure
+    """
+    return plot_topocells_highlighted(
+        adata=adata,
+        topological_loops=topological_loops,
+        loop_indices=[loop_index],
+        title=title or f'Loop {loop_index + 1} Topocells',
+        pcs_viz=pcs_viz,
+        color_col=color_col,
+        hover_cols=hover_cols,
+        **kwargs
+    )
+
+
+def summarize_topocells(adata, topological_loops):
+    """
+    Print summary statistics about topocells across loops.
+    """
+    print("Topocells Summary:")
+    print("=" * 50)
+    
+    all_topocells = set()
+    for i, loop_info in enumerate(topological_loops):
+        if 'topocell_ixs' in loop_info:
+            topocells = set(loop_info['topocell_ixs'])
+            n_topocells = len(topocells)
+            birth = loop_info.get('birth_dist', 0)
+            pers = loop_info.get('pers', 0)
+            
+            print(f"Loop {i+1}: {n_topocells:,} topocells (B:{birth:.3f}, P:{pers:.3f})")
+            all_topocells.update(topocells)
+    
+    n_total_cells = adata.n_obs
+    n_unique_topocells = len(all_topocells)
+    pct_topocells = (n_unique_topocells / n_total_cells) * 100
+    
+    print(f"\nTotal: {n_unique_topocells:,} unique topocells out of {n_total_cells:,} cells ({pct_topocells:.1f}%)")
+
+
+# Example usage:
+"""
+# Summary of topocells
+summarize_topocells(adata, topological_loops)
+
+# Plot all loops' topocells highlighted
+fig1 = plot_topocells_highlighted(
+    adata=adata,
+    topological_loops=topological_loops,
+    title="All Topocells Highlighted",
+    color_col='cell_type',  # Color topocells by cell type
+    hover_cols=['cell_type', 'sample', 'day'],
+    pcs_viz=(0, 1, 2),
+    dot_size_gray=1,  # Small gray dots
+    dot_size_topo=3,  # Larger colored dots
+    show_loops=True   # Also show connections
+)
+
+fig1.show()
+
+# Plot only the first loop's topocells
+fig2 = plot_single_loop_topocells(
+    adata=adata,
+    topological_loops=topological_loops,
+    loop_index=0,  # First loop
+    color_col='somite_stage',
+    hover_cols=['cell_type', 'somite_stage', 'day'],
+    show_loops=True
+)
+
+fig2.show()
+
+# Plot specific loops (e.g., loops 0 and 2)
+fig3 = plot_topocells_highlighted(
+    adata=adata,
+    topological_loops=topological_loops,
+    loop_indices=[0, 2],  # Only loops 1 and 3
+    title="Selected Loops Highlighted",
+    color_col='cell_state',
+    pcs_viz=(1, 2, 3),  # Use PC2, PC3, PC4
+    show_loops=False
+)
+
+fig3.show()
+"""


### PR DESCRIPTION
	1.	Automatic PCA Cutoff & Outlier Detection
	•	find_pca_cutoff: Identifies the elbow point in PCA variance curves.
	•	detect_outliers: Flags cells outside a specified Mahalanobis/PC-based threshold.
	2.	Reproducible Landmark Selection & Subsampling
	•	Refactored prim_tree to accept seed and subsample_frac for reproducible landmark sampling.
	•	Enables fractional subsampling of loop cells during representative-loop extraction.
	3.	Loop Visualization Enhancements
	•	Introduced plot_loops for quick rendering of representative loops.
	•	Added highlight_topocells to mark topological cells within a point-cloud plot.
	4.	Topogene Gradient Scoring & Tutorial
	•	New functions compute “topogenes” by averaging gradient-norm scores over repeated subsamples.
	•	Bundled into tutorial_2, demonstrating end-to-end: loop extraction → circular coords → gradient scoring → gene ranking.